### PR TITLE
Fix for phone number validation.

### DIFF
--- a/js/util/ValidationUtil.js
+++ b/js/util/ValidationUtil.js
@@ -91,7 +91,7 @@
          *      // true
          */
         ValidationUtil.isValidPhoneNumber = function(phoneNumber) {
-            var expression = /\(?([0-9]{3})\)?([ .-]?)([0-9]{3})\2([0-9]{4})/;
+            var expression = /\(?([0-9]{3})\)?([ .-]?)([0-9]{3})\2([0-9]{4})$/;
             return expression.test(phoneNumber);
         };
         /**


### PR DESCRIPTION
Previously a "valid" phone number was the 10-digit number plus anything else.  (e.g. 123-456-7890appleCoffee)
